### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
+      - uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
 
@@ -38,7 +38,7 @@ jobs:
     - name: Generate coverage report
       run: ./gradlew core:codeCoverageReport
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@50ffd5fc58ed613b7848c7604df3a1effc13d659 # v2.1.0
 
   android-test:
     needs: cancel_previous
@@ -62,7 +62,7 @@ jobs:
       - name: Generate coverage report
         run: ./gradlew android:codeCoverageReport
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@50ffd5fc58ed613b7848c7604df3a1effc13d659 # v2.1.0
 
   destination-test:
     needs: cancel_previous
@@ -86,7 +86,7 @@ jobs:
       - name: Generate coverage report
         run: ./gradlew samples:kotlin-android-app-destinations:codeCoverageReport
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@50ffd5fc58ed613b7848c7604df3a1effc13d659 # v2.1.0
 
   security:
     needs: cancel_previous

--- a/.github/workflows/create_jira.yml
+++ b/.github/workflows/create_jira.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@c22a5debd482401472b285de4f6deedf70ddbb92 # master
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@1c54357fdde9dab6273a0e26d67cb175ffffe498 # master
         with:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: Bug


### PR DESCRIPTION
REF: [DX-516](https://linear.app/customerio/issue/DX-516/update-all-github-action-libraries-to-use-sha-instead-of-version) Pins GitHub Actions as part of DX-516.